### PR TITLE
Add: Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*        @greenbone/@greenbone/product-department-developers
+*        @greenbone/product-department-developers


### PR DESCRIPTION
## What

This commit adds a `CODEOWNERS` file to the `.github` directory to indicate which GitHub team owns this repository and is responsible for it.

## Why

Having clear ownership is necessary for resolving issues with the repository in a timely manner and mandated by internal GitHub repository policies.

## References

For details, see DOS-108.
